### PR TITLE
Added support for arm32v7

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,39 @@
+#
+# Copyright 2018 Ji-Young Park(jiyoung.park.dev@gmail.com)
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Use 2-stage builds to reduce size of the final docker image
+#
+
+# build stage
+FROM golang:1.12.6-stretch as builder
+WORKDIR /go/src/github.com/jparklab/synology-csi
+ADD . .
+
+RUN apt update -yq && apt install -y qemu-user-static
+RUN make
+
+FROM arm32v7/debian:10
+LABEL maintainers="Kubernetes Authors"
+LABEL description="Synology CSI Plugin"
+
+COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/
+
+RUN apt install -y debian-archive-keyring && apt update -yq && apt install iproute2 ca-certificates e2fsprogs xfsprogs util-linux open-iscsi -y
+
+COPY --from=builder /go/src/github.com/jparklab/synology-csi/bin/synology-csi-driver-arm /bin/synology-csi-driver
+
+ENTRYPOINT ["/bin/synology-csi-driver"]

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,15 @@
 
 REV=v0.1.0
 
-all: synology-csi-driver
+all: synology-csi-driver synology-csi-driver-arm
 
 synology-csi-driver:
 	mkdir -p bin
 	GO111MODULE=on GOOS=linux go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/synology-csi-driver ./cmd/syno-csi-plugin
+
+synology-csi-driver-arm:
+	mkdir -p bin
+	GO111MODULE=on GOOS=linux GOARCH=arm go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/synology-csi-driver-arm ./cmd/syno-csi-plugin
 
 test:
 	GO111MODULE=on go test ./...


### PR DESCRIPTION
Hi,

I operate a kubernetes cluster on raspberrypi and host volumes on my synology. I therefore need support for arm32v7 docker images.

This is what I did in this PR.