### PR TITLE
add CSI resizer (resize LUN and filesystem without restarting pod)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ FROM alpine:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="Synology CSI Plugin"
 
-RUN apk add --no-cache e2fsprogs xfsprogs util-linux iproute2
+RUN apk add --no-cache e2fsprogs e2fsprogs-extra xfsprogs xfsprogs-extra util-linux iproute2
 COPY --from=compiler /go/src/github.com/jparklab/synology-csi/bin/synology-csi-driver synology-csi-driver
 
 ENTRYPOINT ["/synology-csi-driver"]

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ parameters:
   type: 'FILE'          # if the location has ext4 file system, use FILE for thick provisioning, and THIN for thin provisioning.
                         # for btrfs file system, use BLUN_THICK for thick provisioning, and BLUN for thin provisioning.
 reclaimPolicy: Delete
+allowVolumeExpansion: true # support from Kubernetes 1.16
 ```
 
 ***NOTE:*** if you have already created storage class, you would need to delete the storage class and recreate it.

--- a/deploy/kubernetes/v1.16/resizer.yml
+++ b/deploy/kubernetes/v1.16/resizer.yml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-resizer-sa
+  namespace: synology-csi
+
+---
+# resizer must be able to work with PVs, nodes and VolumeAttachments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-synology-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-synology-resizer-role
+  namespace: synology-csi
+subjects:
+  - kind: ServiceAccount
+    name: csi-resizer-sa
+    namespace: synology-csi
+roleRef:
+  kind: ClusterRole
+  name: csi-synology-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: synology-csi-resizer
+  namespace: synology-csi
+spec:
+  serviceName: "synology-csi-resizer"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synology-csi-resizer
+  template:
+    metadata:
+      labels:
+        app: synology-csi-resizer
+    spec:
+      serviceAccountName: csi-resizer-sa
+      hostNetwork: true
+      containers:
+        - name: csi-resizer
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: jparklab/synology-csi:v1.0.0-kubernetes-1.16.0
+          args:
+            - --nodeid
+            - NotUsed
+            - --endpoint=$(CSI_ENDPOINT)
+            - --synology-config
+            - /etc/synology/syno-config.yml
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: DEVICE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: synology-config
+              mountPath: /etc/synology
+              readOnly: true
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: synology-config
+          secret:
+            secretName: synology-config

--- a/deploy/kubernetes/v1.16/storage_class.yml
+++ b/deploy/kubernetes/v1.16/storage_class.yml
@@ -11,3 +11,4 @@ provisioner: csi.synology.com
 #   location: '/volume1'
 #   type: 'BLUN'
 reclaimPolicy: Delete
+allowVolumeExpansion: true

--- a/deploy/kubernetes/v1.17/resizer.yml
+++ b/deploy/kubernetes/v1.17/resizer.yml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-resizer-sa
+  namespace: synology-csi
+
+---
+# resizer must be able to work with PVs, nodes and VolumeAttachments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-synology-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-synology-resizer-role
+  namespace: synology-csi
+subjects:
+  - kind: ServiceAccount
+    name: csi-resizer-sa
+    namespace: synology-csi
+roleRef:
+  kind: ClusterRole
+  name: csi-synology-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: synology-csi-resizer
+  namespace: synology-csi
+spec:
+  serviceName: "synology-csi-resizer"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synology-csi-resizer
+  template:
+    metadata:
+      labels:
+        app: synology-csi-resizer
+    spec:
+      serviceAccountName: csi-resizer-sa
+      hostNetwork: true
+      containers:
+        - name: csi-resizer
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: jparklab/synology-csi:v1.0.0-kubernetes-1.17.0
+          args:
+            - --nodeid
+            - NotUsed
+            - --endpoint=$(CSI_ENDPOINT)
+            - --synology-config
+            - /etc/synology/syno-config.yml
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: DEVICE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: synology-config
+              mountPath: /etc/synology
+              readOnly: true
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: synology-config
+          secret:
+            secretName: synology-config

--- a/deploy/kubernetes/v1.17/storage_class.yml
+++ b/deploy/kubernetes/v1.17/storage_class.yml
@@ -11,3 +11,4 @@ provisioner: csi.synology.com
 #   location: '/volume1'
 #   type: 'BLUN'
 reclaimPolicy: Retain
+allowVolumeExpansion: true

--- a/deploy/kubernetes/v1.18/resizer.yml
+++ b/deploy/kubernetes/v1.18/resizer.yml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-resizer-sa
+  namespace: synology-csi
+
+---
+# resizer must be able to work with PVs, nodes and VolumeAttachments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-synology-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-synology-resizer-role
+  namespace: synology-csi
+subjects:
+  - kind: ServiceAccount
+    name: csi-resizer-sa
+    namespace: synology-csi
+roleRef:
+  kind: ClusterRole
+  name: csi-synology-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: synology-csi-resizer
+  namespace: synology-csi
+spec:
+  serviceName: "synology-csi-resizer"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synology-csi-resizer
+  template:
+    metadata:
+      labels:
+        app: synology-csi-resizer
+    spec:
+      serviceAccountName: csi-resizer-sa
+      hostNetwork: true
+      containers:
+        - name: csi-resizer
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: jparklab/synology-csi:v1.0.0-kubernetes-1.18.0
+          args:
+            - --nodeid
+            - NotUsed
+            - --endpoint=$(CSI_ENDPOINT)
+            - --synology-config
+            - /etc/synology/syno-config.yml
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: DEVICE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+            - name: synology-config
+              mountPath: /etc/synology
+              readOnly: true
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: synology-config
+          secret:
+            secretName: synology-config

--- a/deploy/kubernetes/v1.18/storage_class.yml
+++ b/deploy/kubernetes/v1.18/storage_class.yml
@@ -11,3 +11,4 @@ provisioner: csi.synology.com
 #   location: '/volume1'
 #   type: 'BLUN'
 reclaimPolicy: Retain
+allowVolumeExpansion: true

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -92,6 +92,7 @@ func NewDriver(nodeID string, endpoint string, synoOption *options.SynologyOptio
 			csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		})
 	csiDriver.AddVolumeCapabilityAccessModes(
 		[]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER})

--- a/pkg/driver/util.go
+++ b/pkg/driver/util.go
@@ -17,6 +17,7 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -46,4 +47,24 @@ func parseVolumeID(volumeID string) (int, int, error) {
 	}
 
 	return targetID, mappingIndex, nil
+}
+
+func validateCapacity(requestBytes, limitBytes int64) (int64, error) {
+	if requestBytes < 0 {
+		return 0, errors.New("request bytes must be positive integer")
+	}
+	if limitBytes < 0 {
+		return 0, errors.New("limit bytes must be positive integer")
+	}
+
+	if limitBytes != 0 && requestBytes > limitBytes {
+		return 0, fmt.Errorf(
+			"request must less than limit: request=%d limit=%d", requestBytes, limitBytes,
+		)
+	}
+
+	if requestBytes == 0 {
+		return 1, nil
+	}
+	return (requestBytes-1)>>30 + 1, nil
 }

--- a/pkg/synology/api/iscsi/lun.go
+++ b/pkg/synology/api/iscsi/lun.go
@@ -127,6 +127,10 @@ type LunAPI interface {
 		volType string, // type of the volume, see LunType for available types
 	) (*Lun, error)
 	Delete(id string) error
+	Update(
+		id string,
+		size int64,
+	) error
 }
 
 type lunAPI struct {
@@ -212,6 +216,20 @@ func (l *lunAPI) Delete(id string) error {
 	_, err := l.apiEntry.Post("delete", url.Values{
 		"uuid": {fmt.Sprintf("\"%s\"", id)},
 	})
+
+	return err
+}
+
+func (l *lunAPI) Update(
+	id string,
+	size int64,
+) error {
+	_, err := l.apiEntry.Post("set", url.Values{
+		"uuid":     {fmt.Sprintf("\"%s\"", id)},
+		"new_size": {fmt.Sprintf("%d", size)},
+	})
+
+	glog.V(5).Infof("Updated a LUN: %s", id)
 
 	return err
 }


### PR DESCRIPTION
Hi!

Thank you for the great product : )
I'm using Synology CSI with DS620slim for my home lab.

I was implemented a CSI resizer. If you want, please merge this.
If PVC spec is changed, LUN will be resized and a file system on the LUN will also be resized without restarting the pod.

* controller-plugin: resize LUN via Synology API
    * add Synology iscsi Update() API
* node-plugin: rescan iSCSI and expand file system (ext3, ext4, and xfs) with online
    * e2fsprogs-extra and xfsprogs-extra package is required for resize2fs and xfs_growfs (dependency for k8s.io/kubernetes/pkg/util/resizefs).

* update manifests
    * add allowVolumeExpansion for StorageClass

A test image is uploaded at amsy810/synology-csi:test .

Ref: https://github.com/jparklab/synology-csi/issues/40
